### PR TITLE
Function split() is deprecated after PHP5.3, use explode()

### DIFF
--- a/magpie/rss_parse.inc
+++ b/magpie/rss_parse.inc
@@ -150,7 +150,7 @@ class MagpieRSS {
         // check for a namespace, and split if found
         $ns = false;
         if ( strpos( $element, ':' ) ) {
-            list($ns, $el) = split( ':', $element, 2); 
+            list($ns, $el) = explode( ':', $element, 2); 
         }
         if ( $ns and $ns != 'rdf' ) {
             $this->current_namespace = $ns;


### PR DESCRIPTION
Errors: Deprecated: Function split() is deprecated from line 153 of rss_parse.inc

[Stack Overflow Answer](http://stackoverflow.com/questions/17815857/deprecated-function-split-is-deprecated-how-to-fix-this-statement)