### PR TITLE
Fix an XSS issue

### DIFF
--- a/feed2js.php
+++ b/feed2js.php
@@ -172,6 +172,9 @@ if (isset($restrict_url) && substr($src_host, strlen($src_host)-strlen($restrict
 	
 	// no feed found by magpie, return error statement
 	if  (!$rss) {
+		//$src needs to be escape before being displayed as an error message, in order to prevent XSS 
+		$src = htmlspecialchars($src);
+		
 		$str.= "document.write('<p class=\"rss-item\">$script_msg<em>Error:</em> Feed failed! Causes may be (1) No data  found for RSS feed $src; (2) There are no items are available for this feed; (3) The RSS feed does not validate.<br /><br /> Please verify that the URL <a href=\"$src\">$src</a> works first in your browser and that the feed passes a <a href=\"http://feedvalidator.org/check.cgi?url=" . urlencode($src) . "\">validator test</a>.</p></div>');\n";
 	
 	

--- a/feed2js.php
+++ b/feed2js.php
@@ -47,7 +47,7 @@ $src = (isset($_GET['src'])) ? $_GET['src'] : '';
 // trap for missing src param for the feed, use a dummy one so it gets displayed.
 if (!$src or strpos($src, 'http://')!=0) $src=  'http://' . $_SERVER['SERVER_NAME'] . dirname($_SERVER['PHP_SELF']) . '/nosource.php';
 
-// test for malicious use of script tages
+// test for malicious use of script tags
 if (strpos($src, '<script>')) {
 	$src = preg_replace("/(\<script)(.*?)(script>)/si", "SCRIPT DELETED", "$src");
 	die("Warning! Attempt to inject javascript detected. Aborted and tracking log updated.");
@@ -154,6 +154,8 @@ if (isset($restrict_url)) {
 	}
 }
 if (isset($restrict_url) && substr($src_host, strlen($src_host)-strlen($restrict_url)) != $restrict_url) {
+	$src = htmlspecialchars($src);
+	
 	$str.= "document.write('<div class=\"rss-box" . $rss_box_id .
 		"\"><p class=\"rss-item\"><em>Error:</em> on feed <strong>" .
 		$src . "</strong>. " .

--- a/feed2php.inc
+++ b/feed2php.inc
@@ -148,6 +148,8 @@ $str = "<div class=\"rss-box" . $rss_box_id . "\">\n";
 
 // no feed found by magpie, return error statement
 if  (!$rss) {
+	$src = htmlspecialchars($src);
+	
 	// error, nothing grabbed
 	$str.= "<p class=\"rss-item\"><em>Error:</em> Feed failed! Causes may be (1) No data  found for RSS feed $src; (2) There are no items are available for this feed; (3) The RSS feed does not validate.<br /><br /> Please verify that the URL <a href=\"$src\">$src</a> works first in your browser and that the feed passes a <a href=\"http://feedvalidator.org/check.cgi?url=" . urlencode($src) . "\">validator test</a>.</p>\n";
 } else {


### PR DESCRIPTION
HTML needs to be escaped before being displayed back to the user

For example:

https://example.com/feed2js.php?src=http://example.com/myrsscontent/%3Cimg+src=xyz+onerror=alert(150)%3E%3Cxss_5db14e84adfa92245a8f9b4dc588ea74/%3E&num=5&utf=y&html=y

would result in javascript being executed on a client machine.