### PR TITLE
PHP 7 Updates

### DIFF
--- a/magpie/rss_cache.inc
+++ b/magpie/rss_cache.inc
@@ -21,7 +21,7 @@ class RSSCache {
     var $MAX_AGE    = 3600;         // when are files stale, default one hour
     var $ERROR      = "";           // accumulate error messages
     
-    function RSSCache ($base='', $age='') {
+    function __construct ($base='', $age='') {
         if ( $base ) {
             $this->BASE_CACHE = $base;
         }

--- a/magpie/rss_parse.inc
+++ b/magpie/rss_parse.inc
@@ -91,7 +91,7 @@ class MagpieRSS {
      *                                  source encoding. (caveat emptor)
      *
      */
-    function MagpieRSS ($source, $output_encoding='ISO-8859-1', 
+    function __construct ($source, $output_encoding='ISO-8859-1', 
                         $input_encoding=null, $detect_encoding=true) 
     {   
         # if PHP xml isn't compiled in, die


### PR DESCRIPTION
Methods can’t have the same name as the class they are in as of PHP 7.