### PR TITLE
Switch from strpos search from <script> tags to parse_url & filter_var approach

### DIFF
--- a/feed2js.php
+++ b/feed2js.php
@@ -47,11 +47,12 @@ $src = (isset($_GET['src'])) ? $_GET['src'] : '';
 // trap for missing src param for the feed, use a dummy one so it gets displayed.
 if (!$src or strpos($src, 'http://')!=0) $src=  'http://' . $_SERVER['SERVER_NAME'] . dirname($_SERVER['PHP_SELF']) . '/nosource.php';
 
-// test for malicious use of script tags
-if (strpos($src, '<script>')) {
-	$src = preg_replace("/(\<script)(.*?)(script>)/si", "SCRIPT DELETED", "$src");
-	die("Warning! Attempt to inject javascript detected. Aborted and tracking log updated.");
-}
+// Filter for malicious use of <script> and related tags. Uses https://www.php.net/manual/en/filter.filters.validate.php, requiring PHP7 or later
+$src = filter_var($src,FILTER_VALIDATE_URL,FILTER_FLAG_PATH_REQUIRED);
+//disasemble src into component parts
+$parsed_url_src = parse_url($src,-1);
+//Re-asemble src, currently only works with absolute URLs
+$src = $parsed_url_src['scheme'].'://'.filter_var($parsed_url_src['host'],FILTER_VALIDATE_DOMAIN).strip_tags($parsed_url_src['path']);
 
 // MAGPIE  SETUP ----------------------------------------------------
 // access configuration settings

--- a/feed2js.php
+++ b/feed2js.php
@@ -50,7 +50,7 @@ if (!$src or strpos($src, 'http://')!=0) $src=  'http://' . $_SERVER['SERVER_NAM
 // Filter for malicious use of <script> and related tags. Uses https://www.php.net/manual/en/filter.filters.validate.php, requiring PHP7 or later
 $src = filter_var($src,FILTER_VALIDATE_URL,FILTER_FLAG_PATH_REQUIRED);
 //disasemble src into component parts
-$parsed_url_src = parse_url($src,-1);
+$parsed_url_src = parse_url($src);
 //Re-asemble src, currently only works with absolute URLs
 $src = $parsed_url_src['scheme'].'://'.filter_var($parsed_url_src['host'],FILTER_VALIDATE_DOMAIN).strip_tags($parsed_url_src['path']);
 

--- a/feed2js.php
+++ b/feed2js.php
@@ -49,9 +49,9 @@ if (!$src or strpos($src, 'http://')!=0) $src=  'http://' . $_SERVER['SERVER_NAM
 
 // Filter for malicious use of <script> and related tags. Uses https://www.php.net/manual/en/filter.filters.validate.php, requiring PHP7 or later
 $src = filter_var($src,FILTER_VALIDATE_URL,FILTER_FLAG_PATH_REQUIRED);
-//disasemble src into component parts
+// Disasemble src into component parts
 $parsed_url_src = parse_url($src);
-//Re-asemble src, currently only works with absolute URLs
+// Re-asemble src, currently only works with absolute URLs
 $src = $parsed_url_src['scheme'].'://'.filter_var($parsed_url_src['host'],FILTER_VALIDATE_DOMAIN).strip_tags($parsed_url_src['path']);
 
 // MAGPIE  SETUP ----------------------------------------------------


### PR DESCRIPTION
This PR is related to issue #30 

Many browsers will accept JavaScript inline in certain properties of tags.
This approach strips all tags from the path, but after filter_var is used to verify the URL src is valid and that the host and path components are valid. There may still be vectors, but this closes many of them.

This approach does require an absolute URL, it will not work with relative paths. I think that's a small use case, but it'll take a lot more processing to work with absolute and relative URLs.

filter_var was introduced into PHP7